### PR TITLE
Integration with auth0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/mumuki/mumukit-auth.git
-  revision: 56bd601fc050da958b22713fe75d68d926c7314f
+  revision: cf823a3e66b999e9caedff2bb00c68784335039a
   branch: master
   specs:
     mumukit-auth (0.1.0)

--- a/app/routes.rb
+++ b/app/routes.rb
@@ -12,7 +12,8 @@ require_relative '../lib/bibliotheca'
 configure do
   enable :cross_origin
 
-  Mongo::Logger.logger       = ::Logger.new('mongo.log')
+  Mongo::Logger.logger = ::Logger.new('mongo.log')
+
 end
 
 helpers do
@@ -20,12 +21,14 @@ helpers do
     yield JSON.parse(request.body.read)
   end
 
-  def auth_token
-    env['HTTP_X_MUMUKI_AUTH_TOKEN']
+  def permissions
+    token = Mumukit::Auth::Token.decode_header(authorization_header)
+    token.verify_client!
+    @permissions ||= token.permissions 'bibliotheca'
   end
 
-  def permissions
-    @permissions ||= Mumukit::Auth::Token.decode(auth_token).permissions
+  def authorization_header
+    env['HTTP_AUTHORIZATION']
   end
 
   def bot

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,10 @@
+require 'mumukit/auth'
+
+Mumukit::Auth.configure do |c|
+  c.client_id = ENV['MUMUKI_BIBLIOTHECA_CLIENT_ID']
+  c.client_secret = ENV['MUMUKI_BIBLIOTHECA_CLIENT_SECRET']
+end
+
 require './app/routes'
 
 run Sinatra::Application

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -39,7 +39,7 @@ describe 'routes' do
 
   describe('get /guides/writable') do
     before do
-      header 'X-Mumuki-Auth-Token', Mumukit::Auth::Token.build('foo/*').encode
+      header 'Authorization', build_auth_header('foo/*')
       get '/guides/writable'
     end
 
@@ -85,7 +85,7 @@ describe 'routes' do
         expect_any_instance_of(Bibliotheca::IO::Export).to receive(:run!)
         allow_any_instance_of(RestClient::Request).to receive(:execute)
 
-        header 'X-Mumuki-Auth-Token', Mumukit::Auth::Token.build('*').encode
+        header 'Authorization', build_auth_header('*')
 
         post '/guides', {slug: 'bar/baz',
                          language: 'haskell',
@@ -100,7 +100,7 @@ describe 'routes' do
         allow_any_instance_of(Bibliotheca::IO::Export).to receive(:run!)
         allow_any_instance_of(RestClient::Request).to receive(:execute)
 
-        header 'X-Mumuki-Auth-Token', Mumukit::Auth::Token.build('*').encode
+        header 'Authorization', build_auth_header('*')
 
         post '/guides', {slug: 'bar/baz',
                          name: 'Baz Guide',
@@ -120,7 +120,7 @@ describe 'routes' do
 
     context 'when request is invalid' do
       it 'reject unauthorized requests' do
-        header 'X-Mumuki-Auth-Token', Mumukit::Auth::Token.build('goo/foo').encode
+        header 'Authorization', build_auth_header('goo/foo')
 
         post '/guides', {slug: 'bar/baz', name: 'Baz Guide', exercises: [{name: 'Exercise 1'}]}.to_json
 
@@ -137,12 +137,12 @@ describe 'routes' do
 
         expect(last_response).to_not be_ok
         expect(last_response.status).to eq 400
-        expect(last_response.body).to json_eq message: 'Nil JSON web token'
+        expect(last_response.body).to json_eq message: 'missing authorization header'
 
       end
 
       it 'reject invalid tokens' do
-        header 'X-Mumuki-Auth-Token', 'fooo'
+        header 'Authorization', 'fooo'
 
         post '/guides', {slug: 'bar/baz',
                          name: 'Baz Guide',
@@ -161,7 +161,7 @@ describe 'routes' do
       expect_any_instance_of(Bibliotheca::Bot).to receive(:register_post_commit_hook!)
     end
     it 'accepts valid requests' do
-      header 'X-Mumuki-Auth-Token', Mumukit::Auth::Token.build('*').encode
+      header 'X-Mumuki-Auth-Token', build_auth_header('*')
       post '/guides/import/pdep-utn/mumuki-funcional-guia-0'
       expect(last_response).to be_ok
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'factory_girl'
 
 require 'rack/test'
 
+require 'mumukit/auth'
+
 require_relative '../lib/bibliotheca'
 require_relative './factories/language_factory'
 
@@ -21,4 +23,14 @@ RSpec::Matchers.define :json_eq do |expected_json_hash|
   match do |actual_json|
     expected_json_hash.with_indifferent_access == ActiveSupport::JSON.decode(actual_json)
   end
+end
+
+require 'base64'
+Mumukit::Auth.configure do |c|
+  c.client_id = 'foo'
+  c.client_secret = Base64.encode64 'bar'
+end
+
+def build_auth_header(permissions_string)
+  Mumukit::Auth::Token.encode_dummy_auth_header(bibliotheca: {permissions: permissions_string})
 end


### PR DESCRIPTION
Not using janitor tokens anymore, but auth0 tokens. 

The change is not so drastic since mumukit-auth already used JWT.

Bibliotheca expect tokens generated by auth0.openid compatible source. In particular, it expects all the openid fields (aud, iat, etc) plus a `user_metadata` field, with the following format:

```json
{
  "bibliotheca": {
    "permissions": "*"
  },
  "classroom": {
    "permissions": "pdep-utn/*"
  }
}
```

There is currently no custom admin view to enter that json. We have to manually build it and enter it through auth0 admin console. 

But it is not a big issue by now, it only affects users of classroom and editor, which are few. Later we could build a tool for admin tasks, which includes giving permissions to a user. It can be done through auth0 REST API 