### PR TITLE
Don't remove everything

### DIFF
--- a/lib/bibliotheca/io.rb
+++ b/lib/bibliotheca/io.rb
@@ -1,6 +1,8 @@
 module Bibliotheca::IO
 end
 
+require_relative './io/git_lib'
+
 require_relative './io/with_file_reading'
 
 require_relative './io/guide_reader'

--- a/lib/bibliotheca/io/export.rb
+++ b/lib/bibliotheca/io/export.rb
@@ -29,7 +29,7 @@ module Bibliotheca::IO
     private
 
     def clear_repo(local_repo)
-      local_repo.remove('*')
+      local_repo.remove %w(description.md corollary.md meta.yml extra.yml expectations.* *_*)
     rescue Git::GitExecuteError => e
       puts 'Nothing to clean, repo seems to be empty'
     end

--- a/lib/bibliotheca/io/git_lib.rb
+++ b/lib/bibliotheca/io/git_lib.rb
@@ -1,0 +1,14 @@
+class Git::Lib
+  # Monkey patch to add --ignore-unmatch option
+  def remove(path = '.', opts = {})
+    arr_opts = %w(-f --ignore-unmatch)
+    arr_opts << ['-r'] if opts[:recursive]
+    arr_opts << '--'
+    if path.is_a?(Array)
+      arr_opts += path
+    else
+      arr_opts << path
+    end
+    command('rm', arr_opts)
+  end
+end


### PR DESCRIPTION
Fixes #34 

This fix is more general than the original issue -  instead of deleting everything except the assets folder, we will remove only files handled by export tool 