### PR TITLE
Feature flexible editor types

### DIFF
--- a/lib/bibliotheca/exercise.rb
+++ b/lib/bibliotheca/exercise.rb
@@ -4,9 +4,14 @@ module Bibliotheca
       Bibliotheca::Schema::Exercise
     end
 
+    def effective_language_name(guide)
+      language || guide.language.name
+    end
+
     def errors
       [
-        ("Invalid layout #{layout}" unless [nil, 'editor_right', 'editor_bottom', 'no_editor', 'upload'].include? layout),
+        ("Invalid layout #{layout}" unless [nil, 'input_right', 'input_bottom'].include? layout),
+        ("Invalid editor #{editor}" unless [nil, 'code', 'multiple_choice', 'single_choice', 'hidden', 'text'].include? editor),
         ('Name must be present' unless name.present?),
         ('Name must not contain a / character' if name.include? '/'),
         ("Invalid exercise type #{type}" unless [nil, 'problem', 'playground'].include? type),

--- a/lib/bibliotheca/schema/exercise.rb
+++ b/lib/bibliotheca/schema/exercise.rb
@@ -10,7 +10,9 @@ module Bibliotheca::Schema::Exercise
 
       {name: :tags, kind: :metadata, reverse: :tag_list,
        transform: proc { |it| it.to_a }, default: []},
-      {name: :layout, kind: :metadata, default: 'editor_right'},
+      {name: :layout, kind: :metadata, default: 'input_right'},
+      {name: :editor, kind: :metadata, default: 'code'},
+
       {name: :type, kind: :metadata, default: 'problem'},
       {name: :extra_visible, kind: :metadata, default: false},
       {name: :language, kind: :metadata},

--- a/migrations/migrate_convert_exercise_layout_editors.rb
+++ b/migrations/migrate_convert_exercise_layout_editors.rb
@@ -1,0 +1,24 @@
+def do_migrate!
+  Bibliotheca::Collection::Languages.migrate_exercises! do |exercise|
+    new_options =
+      case exercise.layout
+        when :editor_bottom then
+          {layout: :input_bottom, editor: :code}
+        when :no_editor then
+          {layout: :input_bottom, editor: :hidden}
+        when :upload then
+          {layout: :input_bottom, editor: :upload}
+        else
+          {layout: :input_right, editor: :code}
+      end
+
+    exercise.layout = new_options[:layout]
+    exercise.editor = new_options[:editor]
+
+    if exercise.language.name == 'text'
+      exercise.editor = :text
+    end
+  end
+end
+
+

--- a/migrations/migrate_convert_exercise_layout_editors.rb
+++ b/migrations/migrate_convert_exercise_layout_editors.rb
@@ -1,22 +1,28 @@
 def do_migrate!
-  Bibliotheca::Collection::Languages.migrate_exercises! do |exercise|
+  Bibliotheca::Collection::Guides.migrate_exercises! do |exercise, guide|
+    puts "migrating #{guide.name}/#{exercise.name}..."
     new_options =
       case exercise.layout
-        when :editor_bottom then
-          {layout: :input_bottom, editor: :code}
-        when :no_editor then
-          {layout: :input_bottom, editor: :hidden}
-        when :upload then
-          {layout: :input_bottom, editor: :upload}
+        when 'editor_right'
+          {layout: 'input_right', editor: 'code'}
+        when 'editor_bottom' then
+          {layout: 'input_bottom', editor: 'code'}
+        when 'no_editor' then
+          {layout: 'input_bottom', editor: 'hidden'}
+        when 'upload' then
+          {layout: 'input_bottom', editor: 'upload'}
         else
-          {layout: :input_right, editor: :code}
+          nil
       end
 
-    exercise.layout = new_options[:layout]
-    exercise.editor = new_options[:editor]
+    new_options.try do
+      exercise.layout = new_options[:layout]
+      exercise.editor = new_options[:editor]
 
-    if exercise.language.name == 'text'
-      exercise.editor = :text
+      if exercise.effective_language_name(guide) == 'text'
+        exercise.editor = 'text'
+      end
+      puts '...updated!'
     end
   end
 end

--- a/spec/data/simple-guide/4_sample_with_layout/meta.yml
+++ b/spec/data/simple-guide/4_sample_with_layout/meta.yml
@@ -3,4 +3,4 @@ tags:
   - bar
   - baz
 locale: en
-layout: editor_bottom
+layout: input_bottom

--- a/spec/data/simple-guide/5_playground/meta.yml
+++ b/spec/data/simple-guide/5_playground/meta.yml
@@ -3,5 +3,5 @@ tags:
   - bar
   - baz
 locale: en
-layout: editor_bottom
+layout: input_bottom
 type: playground

--- a/spec/guide_reader_spec.rb
+++ b/spec/guide_reader_spec.rb
@@ -46,7 +46,7 @@ describe Bibliotheca::IO::GuideReader do
         it { expect(imported_exercise.expectations.size).to eq 2 }
         it { expect(imported_exercise.tag_list).to include *%w(foo bar baz) }
         it { expect(guide.description).to eq "Awesome guide\n" }
-        it { expect(imported_exercise.layout).to eq 'editor_right' }
+        it { expect(imported_exercise.layout).to eq 'input_right' }
 
       end
 
@@ -68,7 +68,7 @@ describe Bibliotheca::IO::GuideReader do
         let(:imported_exercise) { guide.find_exercise_by_id(4) }
 
         it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise.layout).to eq 'editor_bottom' }
+        it { expect(imported_exercise.layout).to eq 'input_bottom' }
       end
 
       context 'when importing playground' do

--- a/spec/guide_spec.rb
+++ b/spec/guide_spec.rb
@@ -11,7 +11,7 @@ describe Bibliotheca::Guide do
          {name: 'Bar',
           description: 'a description',
           test: 'foo bar',
-          layout: 'no_editor',
+          layout: 'input_bottom',
           id: 1},
 
          {type: 'problem',
@@ -22,7 +22,7 @@ describe Bibliotheca::Guide do
          {type: 'playground',
           name: 'Baz',
           tag_list: %w(baz bar),
-          layout: 'editor_bottom',
+          layout: 'input_bottom',
           id: 2}]} }
 
 
@@ -87,7 +87,7 @@ describe Bibliotheca::Guide do
     end
 
     context 'run tests' do
-      let(:exercise) {{id: 1, name: 'foo', type: 'problem', layout: 'editor_right',
+      let(:exercise) {{id: 1, name: 'foo', type: 'problem', layout: 'input_right',
                        description: 'foo', test: %Q{describe "foo" $ do\n it "eq 1" $ do\n  foo = 1},
                        solution: 'foo = 1', expectations: [{binding: 'foo', inspection: 'HasBinding'}],
                        tag_list: [], extra: 'bar = 2'}}

--- a/spec/read_write_spec.rb
+++ b/spec/read_write_spec.rb
@@ -20,7 +20,7 @@ describe 'read-write' do
            test: 'foo bar',
            default_content: '--type here',
            tag_list: %w(baz bar),
-           layout: 'no_editor',
+           layout: 'input_bottom',
            id: 1},
 
           {type: 'problem',
@@ -31,7 +31,7 @@ describe 'read-write' do
 
           {name: 'Baz',
            tag_list: %w(baz bar),
-           layout: 'editor_bottom',
+           layout: 'input_bottom',
            description: 'final description',
            type: 'problem',
            id: 2}]) }
@@ -56,8 +56,8 @@ describe 'read-write' do
   it { expect(imported_guide.exercises.second.name).to eq 'Foo' }
   it { expect(imported_guide.exercises.third.name).to eq 'Baz' }
   it { expect(imported_guide.exercises.first.default_content).to eq '--type here' }
-  it { expect(imported_guide.exercises.first.layout).to eq 'no_editor' }
-  it { expect(imported_guide.exercises.second.layout).to eq 'editor_right' }
+  it { expect(imported_guide.exercises.first.layout).to eq 'input_bottom' }
+  it { expect(imported_guide.exercises.second.layout).to eq 'input_right' }
 
   it { expect(imported_guide.language.name).to eq 'haskell' }
   it { expect(imported_guide.locale).to eq 'en' }

--- a/spec/routes/guides_spec.rb
+++ b/spec/routes/guides_spec.rb
@@ -6,7 +6,7 @@ describe 'routes' do
   before { Bibliotheca::Collection::Languages.insert!(build(:haskell)) }
 
   let(:exercise) {
-    {id: 1, name: 'foo', type: 'problem', layout: 'editor_right', description: 'foo',
+    {id: 1, name: 'foo', type: 'problem', layout: 'input_right', editor: 'code', description: 'foo',
      test: %Q{describe "foo" $ do\n it "bar" $ do\n  foo = True}, solution: 'foo = True',
      manual_evaluation: false,
      expectations: [{binding: 'foo', inspection: 'HasBinding'}], tag_list: [], extra_visible: false} }

--- a/spec/write_spec.rb
+++ b/spec/write_spec.rb
@@ -38,7 +38,7 @@ describe Bibliotheca::IO::GuideWriter do
            id: 200,
            position: 2,
            type: 'problem',
-           layout: 'editor_right',
+           layout: 'input_right',
            test: 'foo bar'}]) }
 
   let(:writer) { Bibliotheca::IO::GuideWriter.new(dir, log) }
@@ -110,7 +110,7 @@ describe Bibliotheca::IO::GuideWriter do
         it { expect(File.read 'spec/data/export/00200_bar/description.md').to eq 'a description' }
 
         it { expect(File.exist? 'spec/data/export/00200_bar/meta.yml').to be true }
-        it { expect(File.read 'spec/data/export/00200_bar/meta.yml').to eq "---\ntags:\n- baz\n- bar\nlayout: editor_right\ntype: problem\nextra_visible: false\nlanguage: \nteacher_info: \nmanual_evaluation: false\n" }
+        it { expect(File.read 'spec/data/export/00200_bar/meta.yml').to eq "---\ntags:\n- baz\n- bar\nlayout: input_right\neditor: code\ntype: problem\nextra_visible: false\nlanguage: \nteacher_info: \nmanual_evaluation: false\n" }
 
 
         it { expect(File.exist? 'spec/data/export/00200_bar/test.hs').to be true }


### PR DESCRIPTION
After merge, run: 

``` bash
bundle exec rake guides:migrate[convert_exercise_layout_editors]
```

Merge right after https://github.com/mumuki/mumuki-atheneum/pull/671 

@fedescarpa in order to merge, we need to update editor so that it:
- Accepts new layouts
- Adds editor field
- Adds choices field, which will be only enabled and visible if editor is single choice or multiple choice
- Only shows default code when editor is code
