### PR TITLE
show complement name instead of slug

### DIFF
--- a/src/scripts/controllers/book-detail-controller.js
+++ b/src/scripts/controllers/book-detail-controller.js
@@ -61,4 +61,10 @@ angular
       }
     }
 
+    $scope.complements = () => _.map($scope.item.complements, toGuide)
+
+    const toGuide = (slug) => {
+      return _.find(guides, { slug: slug });
+    }
+
   });

--- a/src/views/content/books/book-detail.jade
+++ b/src/views/content/books/book-detail.jade
@@ -58,11 +58,13 @@
         span &nbsp;-&nbsp;
         span(ng-bind='guide.slug')
 
-    div(ng-repeat='complement in item.complements')
+    div(ng-repeat='complement in complements()')
       .text-box
         small.pointer.pull-right(ng-click='item.removeComplement($index)')
           i.fa.fa-fw.fa-times
-        span {{ complement }}
+        i(class='{{ complement.icon() }}')
+        span &nbsp;&nbsp;&nbsp;
+        span {{ complement.name }}
 
     br
     ace-with-markdown(header='teacher_info', content='item.teacher_info', foldable='true')


### PR DESCRIPTION
fixes #25

Showing only the name because if the slug is long the complement item occupies two lines and looks horrible :scream_cat: 

![image](https://cloud.githubusercontent.com/assets/1039278/21533056/9cd2a55a-cd35-11e6-8d71-ab7b553e78c8.png)
