### PR TITLE
adding extra attributes field in custom editor

### DIFF
--- a/src/scripts/directives/custom-editor-directive.js
+++ b/src/scripts/directives/custom-editor-directive.js
@@ -8,14 +8,15 @@ angular
       templateUrl: 'views/directives/custom-editor.html',
       scope: {
         exercise: '=',
-        content: '='
+        content: '=',
+        extraAttributes: '='
       },
       controller: ($scope) => {
       },
       compile: (element) => {
         return function (scope, element) {
-          const editor_tag = `mu-${scope.exercise.getLanguage()}-custom-editor`;
-          element.prepend(`<${editor_tag}> </${editor_tag}>`);
+          const editorTag = `mu-${scope.exercise.getLanguage()}-custom-editor`;
+          element.prepend(`<${editorTag} ${scope.extraAttributes || ""} > </${editorTag}>`);
         };
       }
     }

--- a/src/views/directives/evaluation/extra.jade
+++ b/src/views/directives/evaluation/extra.jade
@@ -1,5 +1,5 @@
 div(ng-if='exercise.usesCustomEditor()')
-  custom-editor(exercise="exercise", content='exercise.extra')
+  custom-editor(exercise="exercise", content='exercise.extra', extra-attributes="'start-empty=true'")
 div(ng-if='!exercise.usesCustomEditor()')
   ace-with-toolbar-code(
     content='exercise.extra',


### PR DESCRIPTION
Resolves #135 

Instead of a string we could use an object and build the attributes from that, but i think is more flexible this way

Merge after: https://github.com/mumuki/mumuki-gobstones-runner/pull/90

The moment we need to introduce another custom editor, we should reify that concept.
Extra tab is now coupled to gobstones implementation.